### PR TITLE
Setter numbusds til å ikke kunne gå til 9.0 og høyere.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,11 @@
             <version>${jackson-module-kotlin.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>[5.5,9.0)</version>
+        </dependency>
+        <dependency>
             <groupId>no.nav.common</groupId>
             <artifactId>log</artifactId>
             <version>1.2019.07.11-12.31-0b875ec24c4e</version>


### PR DESCRIPTION
Dette forhindrer et tilfelle der en breaking change i numbusds:9.0 skaper problemer for et annet dependency. 