### PR TITLE
Setter manglende env-variabler

### DIFF
--- a/.nais/config.yaml
+++ b/.nais/config.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: {{namespace}}
   labels:
     team: personbruker
-  annotations:
-    nais.io/read-only-file-system: "false"
 spec:
   image: {{image}}:{{version}}
   team: personbruker


### PR DESCRIPTION
Tidligerer ble logger fra logback lagret til /APP_LOG_HOME_IS_UNDEFINED, ettersom APP_LOG_HOME ikke var definert. Dette skaper problemer ved bruk av read-only filsystem, der kun /tmp er skrivbar. Setter APP_LOG_HOME til /tmp. Definerer også contextName, som også benyttes av logback.